### PR TITLE
Support .* suffix for package names

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/clirr/BufferedListener.java
+++ b/src/main/groovy/org/gradle/api/plugins/clirr/BufferedListener.java
@@ -47,6 +47,20 @@ public class BufferedListener extends DiffListenerAdapter {
             return;
         }
 
+        // Check for .* suffix on each package name
+        for (final String ignoredPackage : ignoredPackages) {
+            if (ignoredPackage.endsWith(".*")) {
+                // Ignore any sub-package of the prefix
+                if (packageName.startsWith(ignoredPackage.substring(0, ignoredPackage.length() - 1))) {
+                    return;
+                }
+                // Ignore the prefix itself
+                if (packageName.equals(ignoredPackage.substring(0, ignoredPackage.length() - 2))) {
+                    return;
+                }
+            }
+        }
+
         final String memberName = extractMemberName(difference);
 
         if (memberName != null


### PR DESCRIPTION
 Fixes issue #2 

I can see this being useful in its own right, but honestly it's a workaround for something else I haven't been able to figure out, which is that clirr is reporting that all of io.netty and org.slf4j have been added to the mongo-java-driver when compared against the 3.0.0 release.
